### PR TITLE
Add guid to end of log stream name (for running multiple instances per conductor)

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,8 @@
     "faucet": "0.0.1",
     "json3": "*",
     "sleep": "^5.2.3",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "guid-typescript": "^1.0.9"
   },
   "scripts": {
     "test:stress": "AWS_ACCESS_KEY_ID=bla AWS_SECRET_ACCESS_KEY=blup ts-node stress_test/index.ts"

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -1,7 +1,7 @@
 import { Config } from '@holochain/tryorama'
 import * as R from 'ramda'
 import { configBatchSimple } from '@holochain/tryorama-stress-utils';
-
+import { Guid } from "guid-typescript";
 import { Orchestrator, tapeExecutor, singleConductor, compose, localOnly, groupPlayersByMachine } from '@holochain/tryorama'
 
 process.on('unhandledRejection', error => {
@@ -87,7 +87,7 @@ if (stressConfig.endpoints) {
 
     metric_publisher = ({scenarioName, playerName}) => ({
         type: 'cloudwatchlogs',
-        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName),
+        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName, ".", Guid.create()),
         log_group_name: '/aws/ec2/holochain/performance/'
     })
 

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -87,7 +87,7 @@ if (stressConfig.endpoints) {
 
     metric_publisher = ({scenarioName, playerName}) => ({
         type: 'cloudwatchlogs',
-        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName, ".", Guid.create().raw()),
+        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName, ".", Guid.raw()),
         log_group_name: '/aws/ec2/holochain/performance/'
     })
 

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -87,7 +87,7 @@ if (stressConfig.endpoints) {
 
     metric_publisher = ({scenarioName, playerName}) => ({
         type: 'cloudwatchlogs',
-        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName, ".", Guid.create()),
+        log_stream_name: "".concat(runName, ".", networkType, ".", 'passthrough-dna', ".", scenarioName, ".", playerName, ".", Guid.create().raw()),
         log_group_name: '/aws/ec2/holochain/performance/'
     })
 


### PR DESCRIPTION
WIP: Fixes sequence token errors when running w/multiple instance per conductor.