### PR TITLE
Simplest possible "stress" test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+lib/
 node_modules/
 target/
 .cargo/

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -6,7 +6,7 @@ import { Batch } from '@holochain/tryorama-stress-utils'
 const trace = R.tap(x => console.log('{T}', x))
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
-module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
+module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
     const totalInstances = N*C*I
     const totalConductors = N*C
 
@@ -28,11 +28,13 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
         }))
         console.log("============================================\nall nodes have started\n============================================")
         console.log(`beginning test with sample size: ${sampleSize}`)
-        await delay(45000)
+        if spinUpDelay == 0 {
+            await s.consistency()
+        } else {
+            await delay(spinUpDelay)
+        }
 
         const batch = new Batch(players).iteration('parallel')
-
-//        await s.consistency()
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
         let results = []

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -40,8 +40,8 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
         const agentSet = new Set(agentIds)
-        console.log('agentIds: ', agentIds.length)
-        console.log('agentSet: ', agentSet.size)
+        console.log('agentIds: ', agentIds.length, JSON.stringify(agentIds))
+        console.log('agentSet: ', agentSet.size, JSON.stringify(Array.from(agentSet)))
 
         let tries = 0
         let last_results = []

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -68,13 +68,11 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
             if (JSON.stringify(expected)==JSON.stringify(results)) {
                 console.log("it worked", expected, results)
                 t.pass()
-                t.end()
                 break
             } else {
                 if (JSON.stringify(last_results)==JSON.stringify(results)) {
                     console.log("it failed", expected, results)
                     t.fail('it failed')
-                    t.end()
                     break
                 } else {
                     tries += 1

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -1,0 +1,35 @@
+import { Config } from '@holochain/tryorama'
+import * as R from 'ramda'
+import { Batch } from '@holochain/tryorama-stress-utils'
+
+
+const trace = R.tap(x => console.log('{T}', x))
+
+module.exports = (scenario, configBatch, N, C, I) => {
+    const totalInstances = N*C*I
+    const totalConductors = N*C
+
+    scenario('all agents exists', async (s, t) => {
+        const players = R.sortBy(p => parseInt(p.name, 10), R.values(await s.players(configBatch(totalConductors, I), false)))
+
+        await Promise.all(players.map(player => player.spawn()))
+
+        const batch = new Batch(players).iteration('series')
+
+        await s.consistency()
+
+        const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
+        let results = []
+        await batch.mapInstances(async instance => {
+            for (const id of agentIds) {
+                if (instance.agentAddress != id) {
+                    const result = await instance.call('main', 'get_entry', {address: instance.agentAddress})
+                    results.push( Boolean(result.Ok) )
+                }
+            }
+        })
+        console.log("RESULTS:", results)
+        // All results contain the full set of other nodes
+        t.deepEqual(results , R.repeat(true,totalInstances*(totalInstances-1)))
+    })
+}

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -23,7 +23,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
         // const getWait = 100
 
         await Promise.all(players.map(async player => {
-            await delay(Math.random()*startupSpacing)
+            //await delay(Math.random()*startupSpacing)
             return player.spawn()
         }))
         console.log("============================================\nall nodes have started\n============================================")

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -6,40 +6,52 @@ import { Batch } from '@holochain/tryorama-stress-utils'
 const trace = R.tap(x => console.log('{T}', x))
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
-module.exports = (scenario, configBatch, N, C, I) => {
+module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
     const totalInstances = N*C*I
     const totalConductors = N*C
+
+    if (!sampleSize) {
+        sampleSize = 1
+    }
 
     scenario('all agents exists', async (s, t) => {
         const players = R.sortBy(p => parseInt(p.name, 10), R.values(await s.players(configBatch(totalConductors, I), false)))
 
         // range of random number of milliseconds to wait before startup
-        const startupSpacing = 10000
+        // const startupSpacing = 10000
         // number of milliseconds to wait between gets
-        const getWait = 100
+        // const getWait = 100
 
         await Promise.all(players.map(async player => {
             await delay(Math.random()*startupSpacing)
             return player.spawn()
         }))
+        console.log("============================================\nall nodes have started\n============================================")
 
-        const batch = new Batch(players).iteration('series')
+        const batch = new Batch(players).iteration('parallel')
 
-        await s.consistency()
+        // await s.consistency()
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
         let results = []
+        let i = 0
+        let checkedCount = 0;
+        let mod = Math.floor(totalInstances/sampleSize)
         await batch.mapInstances(async instance => {
-            for (const id of agentIds) {
-                if (instance.agentAddress != id) {
-                    await delay(getWait)
-                    const result = await instance.call('main', 'get_entry', {address: instance.agentAddress})
-                    results.push( Boolean(result.Ok) )
+            if  ( i % mod == 0) {
+                checkedCount += 1
+                console.log(`\n-------------------------------------------\ngetting ${totalInstances} entries for ${i} (${instance.agentAddress})\n---------------------------\n`)
+                for (const id of agentIds) {
+                    if (instance.agentAddress != id) {
+                        // await delay(getWait)
+                        const result = await instance.call('main', 'get_entry', {address: instance.agentAddress})
+                        results.push( Boolean(result.Ok) )
+                    }
                 }
             }
+            i+=1
         })
-        console.log("RESULTS:", results)
         // All results contain the full set of other nodes
-        t.deepEqual(results , R.repeat(true,totalInstances*(totalInstances-1)))
+        t.deepEqual(results , R.repeat(true,checkedCount*(totalInstances-1)))
     })
 }

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -20,7 +20,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
         // range of random number of milliseconds to wait before startup
         // const startupSpacing = 10000
         // number of milliseconds to wait between gets
-        // const getWait = 100
+        const getWait = 20
 
         await Promise.all(players.map(async player => {
             //await delay(Math.random()*startupSpacing)
@@ -31,7 +31,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
 
         const batch = new Batch(players).iteration('parallel')
 
-        // await s.consistency()
+//        await s.consistency()
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
         let results = []
@@ -44,7 +44,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
                 console.log(`\n-------------------------------------------\ngetting ${totalInstances} entries for ${i} (${instance.agentAddress})\n---------------------------\n`)
                 for (const id of agentIds) {
                     if (instance.agentAddress != id) {
-                        // await delay(getWait)
+                        await delay(getWait)
                         const result = await instance.call('main', 'get_entry', {address: id})
                         results.push( Boolean(result.Ok) )
                     }

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -4,6 +4,7 @@ import { Batch } from '@holochain/tryorama-stress-utils'
 
 
 const trace = R.tap(x => console.log('{T}', x))
+const delay = ms => new Promise(r => setTimeout(r, ms))
 
 module.exports = (scenario, configBatch, N, C, I) => {
     const totalInstances = N*C*I
@@ -12,7 +13,13 @@ module.exports = (scenario, configBatch, N, C, I) => {
     scenario('all agents exists', async (s, t) => {
         const players = R.sortBy(p => parseInt(p.name, 10), R.values(await s.players(configBatch(totalConductors, I), false)))
 
-        await Promise.all(players.map(player => player.spawn()))
+        // range of random number of milliseconds to wait before startup
+        const startupSpacing = 10000
+
+        await Promise.all(players.map(async player => {
+            await delay(Math.random()*startupSpacing)
+            return player.spawn()
+        }))
 
         const batch = new Batch(players).iteration('series')
 

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -10,7 +10,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
     const totalInstances = N*C*I
     const totalConductors = N*C
 
-    if (!sampleSize) {
+    if (sampleSize === undefined) {
         sampleSize = 1
     }
 

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -39,6 +39,9 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
         const batch = new Batch(players).iteration('parallel')
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
+        const agentSet = new Set(agentIds)
+        console.log('agentIds: ', agentIds.length)
+        console.log('agentSet: ', agentSet.size)
 
         let tries = 0
         let last_results = []
@@ -64,12 +67,15 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
             let expected =  R.repeat(true,checkedCount*(totalInstances-1))
             if (JSON.stringify(expected)==JSON.stringify(results)) {
                 console.log("it worked", expected, results)
-                t.assert(true)
+                t.pass()
+                t.end()
                 break
             } else {
                 if (JSON.stringify(last_results)==JSON.stringify(results)) {
                     console.log("it failed", expected, results)
-                    t.assert(false)
+                    t.fail('it failed')
+                    t.end()
+                    break
                 } else {
                     tries += 1
                     last_results = results

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -45,7 +45,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
                 for (const id of agentIds) {
                     if (instance.agentAddress != id) {
                         // await delay(getWait)
-                        const result = await instance.call('main', 'get_entry', {address: instance.agentAddress})
+                        const result = await instance.call('main', 'get_entry', {address: id})
                         results.push( Boolean(result.Ok) )
                     }
                 }

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -28,7 +28,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
         }))
         console.log("============================================\nall nodes have started\n============================================")
         console.log(`beginning test with sample size: ${sampleSize}`)
-        if spinUpDelay == 0 {
+        if (spinUpDelay == 0) {
             await s.consistency()
         } else {
             await delay(spinUpDelay)

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -27,6 +27,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
             return player.spawn()
         }))
         console.log("============================================\nall nodes have started\n============================================")
+        console.log(`beginning test with sample size: ${sampleSize}`)
 
         const batch = new Batch(players).iteration('parallel')
 

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -28,6 +28,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize) => {
         }))
         console.log("============================================\nall nodes have started\n============================================")
         console.log(`beginning test with sample size: ${sampleSize}`)
+        await delay(45000)
 
         const batch = new Batch(players).iteration('parallel')
 

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -29,8 +29,10 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
         console.log("============================================\nall nodes have started\n============================================")
         console.log(`beginning test with sample size: ${sampleSize}`)
         if (spinUpDelay == 0) {
+            console.log("waiting for consistency")
             await s.consistency()
         } else {
+            console.log(`spin up delay ${spinUpDelay}`)
             await delay(spinUpDelay)
         }
 

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -54,7 +54,6 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
                     for (const id of agentIds) {
                         if (instance.agentAddress != id) {
                             await delay(getWait)
-                            console.log(`GETTING ENTRY FOR ${id}`)
                             const result = await instance.call('main', 'get_entry', {address: id})
                             results.push( Boolean(result.Ok) )
                         }

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -15,6 +15,8 @@ module.exports = (scenario, configBatch, N, C, I) => {
 
         // range of random number of milliseconds to wait before startup
         const startupSpacing = 10000
+        // number of milliseconds to wait between gets
+        const getWait = 100
 
         await Promise.all(players.map(async player => {
             await delay(Math.random()*startupSpacing)
@@ -30,6 +32,7 @@ module.exports = (scenario, configBatch, N, C, I) => {
         await batch.mapInstances(async instance => {
             for (const id of agentIds) {
                 if (instance.agentAddress != id) {
+                    await delay(getWait)
                     const result = await instance.call('main', 'get_entry', {address: instance.agentAddress})
                     results.push( Boolean(result.Ok) )
                 }

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -143,7 +143,7 @@ if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
 
 if (stressConfig.tests["sanity"]  && !stressConfig.tests["sanity"].skip) {
     console.log("running sanity")
-    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay, stressConfig.tests["sanity"].retryDelay, stressConfig.tests["sanity"].retries)
+    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"])
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -28,7 +28,7 @@ switch (networkType) {
   case 'sim2h':
     network = {
       type: 'sim2h',
-      sim2h_url: "wss://localhost:9002",
+      sim2h_url: "ws://localhost:9002",
     }
     break
   case 'sim2h_public':
@@ -49,8 +49,8 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 // default stress test is local (because there are no endpoints specified)
 const defaultStressConfig = {
     nodes: 1,
-    conductors: 5,
-    instances: 8,
+    conductors: 2,
+    instances: 2,
     endpoints: undefined,
     tests: {
         allOn: {
@@ -68,7 +68,7 @@ const defaultStressConfig = {
         },
         easy: {
             skip: false,
-            spinUpDelay: 0,
+            spinUpDelay: 10,
         }
     }
 }

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -49,8 +49,8 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 // default stress test is local (because there are no endpoints specified)
 const defaultStressConfig = {
     nodes: 1,
-    conductors: 2,
-    instances: 100,
+    conductors: 30,
+    instances: 1,
     endpoints: undefined,
     tests: {
         allOn: {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -143,7 +143,7 @@ if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
 
 if (stressConfig.tests["sanity"]  && !stressConfig.tests["sanity"].skip) {
     console.log("running sanity")
-    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay)
+    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay, stressConfig.tests["sanity"].retryDelay stressConfig.tests["sanity"].retries)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -134,7 +134,7 @@ if (stressConfig.tests["allOn"]  && !stressConfig.tests["allOn"].skip) {
 
 if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
     console.log("running easy")
-    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["easy"].sampleSize)
+    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["easy"].sampleSize, stressConfig.tests["easy"].spinUpDelay)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -134,7 +134,7 @@ if (stressConfig.tests["allOn"]  && !stressConfig.tests["allOn"].skip) {
 
 if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
     console.log("running easy")
-    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances)
+    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.sampleSize)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -67,8 +67,11 @@ const defaultStressConfig = {
             skip: true
         },
         easy: {
-            skip: false,
+            skip: true,
             spinUpDelay: 10,
+        },
+        sanity: {
+            skip: false
         }
     }
 }
@@ -136,6 +139,11 @@ if (stressConfig.tests["allOn"]  && !stressConfig.tests["allOn"].skip) {
 if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
     console.log("running easy")
     require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["easy"].sampleSize, stressConfig.tests["easy"].spinUpDelay)
+}
+
+if (stressConfig.tests["sanity"]  && !stressConfig.tests["sanity"].skip) {
+    console.log("running sanity")
+    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -49,8 +49,8 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 // default stress test is local (because there are no endpoints specified)
 const defaultStressConfig = {
     nodes: 1,
-    conductors: 10,
-    instances: 1,
+    conductors: 5,
+    instances: 8,
     endpoints: undefined,
     tests: {
         allOn: {
@@ -67,7 +67,8 @@ const defaultStressConfig = {
             skip: true
         },
         easy: {
-            skip: false
+            skip: false,
+            spinUpDelay: 0,
         }
     }
 }

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -49,7 +49,7 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 // default stress test is local (because there are no endpoints specified)
 const defaultStressConfig = {
     nodes: 1,
-    conductors: 30,
+    conductors: 10,
     instances: 1,
     endpoints: undefined,
     tests: {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -50,7 +50,7 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 const defaultStressConfig = {
     nodes: 1,
     conductors: 2,
-    instances: 2,
+    instances: 100,
     endpoints: undefined,
     tests: {
         allOn: {
@@ -79,7 +79,7 @@ const runName = process.argv[2] || ""+Date.now()  // default exam name is just a
 const stressConfig = process.argv[3] ? require(process.argv[3]) : defaultStressConfig
 
 const dnaLocal = Config.dna('../dist/passthrough-dna.dna.json', 'passthrough')
-const dnaRemote = Config.dna('https://github.com/holochain/passthrough-dna/releases/download/v0.0.6/passthrough-dna.dna.json', 'passthrough')
+const dnaRemote = Config.dna('https://github.com/holochain/passthrough-dna/releases/download/v0.0.7-rc1/passthrough-dna.dna.json', 'passthrough')
 let chosenDna = dnaLocal;
 
 let metric_publisher;

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -117,7 +117,7 @@ const batcher = (numConductors, instancesPerConductor) => configBatchSimple(
   commonConfig
 )
 
-console.log(`Running stress test id=${runName} with Nodes=${stressConfig.nodes} Conductors=${stressConfig.conductors}, Instances=${stressConfig.instances}`)
+console.log(`Running stress test id=${runName} with Config: \n`, stressConfig)
 
 if (stressConfig.tests == undefined) {
   stressConfig.tests = {
@@ -134,7 +134,7 @@ if (stressConfig.tests["allOn"]  && !stressConfig.tests["allOn"].skip) {
 
 if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
     console.log("running easy")
-    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.sampleSize)
+    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["easy"].sampleSize)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -48,13 +48,13 @@ if (process.env.HC_TRANSPORT_CONFIG) {
 
 // default stress test is local (because there are no endpoints specified)
 const defaultStressConfig = {
-  nodes: 1,
+    nodes: 1,
     conductors: 10,
     instances: 1,
     endpoints: undefined,
     tests: {
         allOn: {
-            skip: false
+            skip: true
         },
         telephoneGame: {
             skip: true
@@ -64,8 +64,11 @@ const defaultStressConfig = {
             count: 10
         },
         directMessage: {
-            skip: false
+            skip: true
         },
+        easy: {
+            skip: false
+        }
     }
 }
 
@@ -127,6 +130,11 @@ if (stressConfig.tests == undefined) {
 if (stressConfig.tests["allOn"]  && !stressConfig.tests["allOn"].skip) {
   console.log("running all-on")
   require('./all-on')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances)
+}
+
+if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
+    console.log("running easy")
+    require('./easy')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -143,7 +143,7 @@ if (stressConfig.tests["easy"]  && !stressConfig.tests["easy"].skip) {
 
 if (stressConfig.tests["sanity"]  && !stressConfig.tests["sanity"].skip) {
     console.log("running sanity")
-    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay, stressConfig.tests["sanity"].retryDelay stressConfig.tests["sanity"].retries)
+    require('./sanity')(orchestrator.registerScenario, batcher, stressConfig.nodes, stressConfig.conductors, stressConfig.instances, stressConfig.tests["sanity"].spinUpDelay, stressConfig.tests["sanity"].retryDelay, stressConfig.tests["sanity"].retries)
 }
 
 if (stressConfig.tests["telephoneGame"] && !stressConfig.tests["telephoneGame"].skip) {

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -1,0 +1,68 @@
+import { Config } from '@holochain/tryorama'
+import * as R from 'ramda'
+import { Batch } from '@holochain/tryorama-stress-utils'
+
+
+const trace = R.tap(x => console.log('{T}', x))
+const delay = ms => new Promise(r => setTimeout(r, ms))
+
+module.exports = (scenario, configBatch, N, C, I, spinUpDelay) => {
+    const totalInstances = N*C*I
+    const totalConductors = N*C
+
+    scenario('all hashes are available somewhere gettable', async (s, t) => {
+        const players = R.sortBy(p => parseInt(p.name, 10), R.values(await s.players(configBatch(totalConductors, I), false)))
+
+        // range of random number of milliseconds to wait before startup
+        // const startupSpacing = 10000
+        // number of milliseconds to wait between gets
+        const getWait = 20
+
+        await Promise.all(players.map(async player => {
+            //await delay(Math.random()*startupSpacing)
+            return player.spawn()
+        }))
+        console.log("============================================\nall nodes have started\n============================================")
+        console.log(`beginning dht sanity test`)
+        if (spinUpDelay == 0) {
+            console.log("no spin-up delay given using tryorama consistency waiting")
+            await s.consistency()
+        } else {
+            console.log(`spin up delay ${spinUpDelay}`)
+            await delay(spinUpDelay)
+        }
+
+        const batch = new Batch(players).iteration('series')
+
+        const agentAddresses = await batch.mapInstances(async instance => instance.agentAddress)
+        const agentSet = new Set(agentAddresses)
+        console.log('agentAddresses: ', agentAddresses.length, JSON.stringify(agentAddresses))
+        console.log('agentSet: ', agentSet.size, JSON.stringify(Array.from(agentSet)))
+
+        const holding_map = await getHolding(batch)
+        console.log(holding_map)
+    })
+}
+
+const getHolding = async (batch: Batch) => {
+    let DHTresult = {
+        entries: {}
+    }
+    DHTresult["holding"] = await batch.mapInstances(async instance => {
+        const id = `${instance.id}:${instance.agentAddress}`
+        console.log(`calling state dump for instance ${id})`)
+        const dump = await instance.stateDump()
+        const heldHashes = R.keys(dump.held_aspects)
+        const sourceChains = R.values(dump.source_chain)
+        console.log("SOURCE:", sourceChains)
+        const entryMap = {}
+        for (const entry of sourceChains) {
+            console.log("ENTRY:", entry)
+            DHTresult.entries[entry.entry_address] = true
+        }
+        const result = {}
+        result[id] = heldHashes
+        return result
+    })
+    return DHTresult
+}

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -49,8 +49,8 @@ module.exports = (scenario, configBatch, N, C, I, testConfig) => {
             await delay(spinUpDelay)
         }
 
+        let batch = new Batch(players).iteration('parallel')
         if (commitCount > 0) {
-            const batch = new Batch(players).iteration('parallel')
             console.log(`asking all nodes to commit ${commitCount} entries`)
             let i = 0
             while (i < commitCount) {
@@ -64,7 +64,7 @@ module.exports = (scenario, configBatch, N, C, I, testConfig) => {
             }
         }
 
-        const batch = new Batch(players).iteration('series')
+        batch.iteration('series')
         const agentAddresses = await batch.mapInstances(async instance => instance.agentAddress)
         const agentSet = new Set(agentAddresses)
         console.log('agentAddresses: ', agentAddresses.length, JSON.stringify(agentAddresses))

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -60,7 +60,7 @@ module.exports = (scenario, configBatch, N, C, I, spinUpDelay, retryDelay, retri
             console.log("all not held, retrying after delay")
             await delay(retryDelay)
         }
-        if (tries == max_tries) {
+        if (tries == retries) {
             t.fail()
         }
     })

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -46,12 +46,11 @@ module.exports = (scenario, configBatch, N, C, I, spinUpDelay, retryDelay, retri
         console.log('agentAddresses: ', agentAddresses.length, JSON.stringify(agentAddresses))
         console.log('agentSet: ', agentSet.size, JSON.stringify(Array.from(agentSet)))
 
-        const dht_state = await getDHTstate(batch)
-
         let tries = 0
         while (tries < retries) {
             tries += 1
             console.log(`Checking holding: try ${tries}`)
+            const dht_state = await getDHTstate(batch)
             if (checkHolding(dht_state)) {
                 console.log("all are held")
                 t.pass()

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -50,6 +50,7 @@ module.exports = (scenario, configBatch, N, C, I, testConfig) => {
         }
 
         if (commitCount > 0) {
+            const batch = new Batch(players).iteration('parallel')
             console.log(`asking all nodes to commit ${commitCount} entries`)
             let i = 0
             while (i < commitCount) {
@@ -58,12 +59,12 @@ module.exports = (scenario, configBatch, N, C, I, testConfig) => {
                 const commitResults = await batch.mapInstances(instance =>
                                                                instance.call('main', 'commit_entry', { content: trace(`entry-${instance.player.name}-${instance.id}-${i}`) })
                                                               )
-                //const hashes = commitResults.map(x => x.Ok)
+                const hashes = commitResults.map(x => x.Ok)
+                console.log(`commit result ${hashes}`)
             }
         }
 
         const batch = new Batch(players).iteration('series')
-
         const agentAddresses = await batch.mapInstances(async instance => instance.agentAddress)
         const agentSet = new Set(agentAddresses)
         console.log('agentAddresses: ', agentAddresses.length, JSON.stringify(agentAddresses))

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -41,16 +41,20 @@ module.exports = (scenario, configBatch, N, C, I, spinUpDelay) => {
 
         const dht_state = await getDHTstate(batch)
 
-        let tries = 3
-        while (tries > 0) {
+        let tries = 0
+        const max_tries = 5
+        while (tries < max_tries) {
+            tries += 1
+            console.log(`Checking holding: try ${tries}`)
             if (checkHolding(dht_state)) {
+                console.log("all are held")
                 t.pass()
                 break
             }
-            tries =- 1
+            console.log("all not held, retrying after delay")
             await delay(10000)
         }
-        if (tries == 0) {
+        if (tries == max_tries) {
             t.fail()
         }
     })

--- a/test/stress_test/sanity.ts
+++ b/test/stress_test/sanity.ts
@@ -117,9 +117,9 @@ const getDHTstate = async (batch: Batch) => {
         console.log(`calling state dump for instance ${id})`)
         const dump = await instance.stateDump()
         const held_addresses = R.keys(dump.held_aspects)
-        const source_chains = R.values(dump.source_chain)
+        const sourceChain = R.values(dump.source_chain)
         const entryMap = {}
-        for (const entry of source_chains) {
+        for (const entry of sourceChain) {
             if (entry.entry_type != "Dna" && entry.entry_type != "CapTokenGrant") {
                 entries_map[entry.entry_address] = true
             }

--- a/zomes/main/code/src/lib.rs
+++ b/zomes/main/code/src/lib.rs
@@ -9,7 +9,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate holochain_json_derive;
 
-use holochain_wasm_utils::api_serialization::get_links::GetLinksResult;
+use holochain_wasm_utils::api_serialization::{get_links::GetLinksResult, get_entry::GetEntryOptions};
 use hdk::{
     entry_definition::ValidatingEntryType,
     error::ZomeApiResult,
@@ -113,12 +113,15 @@ mod my_zome {
 
     #[zome_fn("hc_public")]
     fn get_entry(address: Address) -> ZomeApiResult<Option<Entry>> {
-        hdk::get_entry(&address)
+        let mut options = GetEntryOptions::default();
+        options.timeout = Timeout::new(2000);
+        Ok(hdk::get_entry_result(&address, options)?.latest())
+//        hdk::get_entry(&address)
     }
 
     #[zome_fn("hc_public")]
     fn update_entry(
-        new_content: String, 
+        new_content: String,
         address: Address
     ) -> ZomeApiResult<Address> {
         hdk::update_entry(
@@ -134,8 +137,8 @@ mod my_zome {
 
     #[zome_fn("hc_public")]
     fn link_entries(
-        base: Address, 
-        target: Address, 
+        base: Address,
+        target: Address,
     ) -> ZomeApiResult<Address> {
         hdk::link_entries(&base, &target, "", "")
     }
@@ -151,15 +154,15 @@ mod my_zome {
 
     #[zome_fn("hc_public")]
     fn get_links(
-        base: Address, 
+        base: Address,
     ) -> ZomeApiResult<GetLinksResult> {
         hdk::get_links(&base, LinkMatch::Any, LinkMatch::Any)
     }
 
     #[zome_fn("hc_public")]
     fn send(
-        to_agent: Address, 
-        payload: String, 
+        to_agent: Address,
+        payload: String,
     ) -> ZomeApiResult<String> {
         hdk::send(to_agent, payload, Timeout::new(5000))
     }


### PR DESCRIPTION
Adds a scenario which simply confirms that all the nodes can get the agentID entry of all the other nodes. This is meant to be the simplest of all stress tests.