### PR TITLE
Setup for sharding aware tryorama

### DIFF
--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "@holochain/hachiko": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.5.1.tgz",
-      "integrity": "sha512-4qY8mNaOZ/YVXdeeuYVOHcA6tXpksxGA64qHILnO/BHxqNt4q8KOUlIYJQYB/wCddGz+DzYU0k+/v5475O2dqA==",
+      "version": "0.5.2-dev.1",
+      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.5.2-dev.1.tgz",
+      "integrity": "sha512-88CrIM2WEG4KGRskoefDf6mLjN7L9FmQGFNGllZ4b6mwnl6Snh7LA3S7zycLwZDAcTV40JjhV8GvhDLQUMj6Bw==",
       "requires": {
         "colors": "^1.3.3",
         "lodash": "^4.17.15",
@@ -41,11 +41,11 @@
       }
     },
     "@holochain/tryorama": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.3.0.tgz",
-      "integrity": "sha512-+RpaCJYEl8VytUia6/wx13JoDmL5IkFteKDqP2RirRJa1EARmFqYKC01iflKmb83tzWEbDst7qfFS8SEkFQm/g==",
+      "version": "0.3.2-dev.2",
+      "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.3.2-dev.2.tgz",
+      "integrity": "sha512-qVOigsgvb0LtFiO5hlziKXp4z5sXPyzNzOfaAYJoxPSnhhtoe9cbNp3Pf8pCnZOJZn8WvlUDzgFeD3nevYVAmA==",
       "requires": {
-        "@holochain/hachiko": "^0.5.1",
+        "@holochain/hachiko": "^0.5.2-dev.1",
         "@holochain/hc-web-client": "^0.5.0",
         "@iarna/toml": "^2.2.3",
         "async-mutex": "^0.1.4",
@@ -64,14 +64,51 @@
       }
     },
     "@holochain/tryorama-stress-utils": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@holochain/tryorama-stress-utils/-/tryorama-stress-utils-0.0.6.tgz",
-      "integrity": "sha512-Jd7hbSVq0vbJKgMjzrh5wPIAkvz1ZLIZp9PMMpVCA49Ov8fT7W+Nu9CWUcbz7QLI+/eE4kLn3rcxuqAQGKMysg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@holochain/tryorama-stress-utils/-/tryorama-stress-utils-0.0.10.tgz",
+      "integrity": "sha512-c835Np1rf6sn+dL4Cf1Yk9GZgyA4gwmNmM1CYXQG7HyuJnBG/8eEIVGioT1TkBUYKURDu/g+/G7rviXSEix71w==",
       "requires": {
-        "@holochain/tryorama": "^0.3.0-rc.3",
+        "@holochain/tryorama": "^0.3.1-rc.2",
         "lodash": "^4.17.15",
         "moniker": "^0.1.2",
-        "ramda": "^0.26.1"
+        "ramda": "^0.26.1",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "@holochain/hachiko": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.5.1.tgz",
+          "integrity": "sha512-4qY8mNaOZ/YVXdeeuYVOHcA6tXpksxGA64qHILnO/BHxqNt4q8KOUlIYJQYB/wCddGz+DzYU0k+/v5475O2dqA==",
+          "requires": {
+            "colors": "^1.3.3",
+            "lodash": "^4.17.15",
+            "winston": "^3.2.1",
+            "winston-null": "^2.0.0"
+          }
+        },
+        "@holochain/tryorama": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.3.1.tgz",
+          "integrity": "sha512-DGeUZkh+OCR8/l9hvpJLqqJeakK5Ujs4mEi/7vz1BuBfFwSNfxRhr7029qljMgE5uUg4m7UKCWauBHUyBcF7JA==",
+          "requires": {
+            "@holochain/hachiko": "^0.5.1",
+            "@holochain/hc-web-client": "^0.5.0",
+            "@iarna/toml": "^2.2.3",
+            "async-mutex": "^0.1.4",
+            "axios": "^0.19.0",
+            "base-64": "^0.1.0",
+            "colors": "^1.3.3",
+            "fp-ts": "^2.0.5",
+            "get-port": "^5.0.0",
+            "io-ts": "^2.0.1",
+            "io-ts-reporters": "^1.0.0",
+            "lodash": "^4.17.15",
+            "memoizee": "^0.4.14",
+            "ramda": "^0.26.1",
+            "uuid": "^3.3.3",
+            "winston": "^3.2.1"
+          }
+        }
       }
     },
     "@iarna/toml": {

--- a/test/package.json
+++ b/test/package.json
@@ -5,8 +5,8 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.3.0",
-    "@holochain/tryorama-stress-utils": "0.0.6",
+    "@holochain/tryorama": "^0.3.2-dev.2",
+    "@holochain/tryorama-stress-utils": "0.0.10",
     "ramda": "^0.26.1",
     "faucet": "0.0.1",
     "json3": "*",
@@ -14,6 +14,8 @@
     "tape": "^4.9.1"
   },
   "scripts": {
-    "test:stress": "AWS_ACCESS_KEY_ID=bla AWS_SECRET_ACCESS_KEY=blup ts-node stress_test/index.ts"
+    "build": "tsc",
+    "test:stress": "npm run build && AWS_ACCESS_KEY_ID=bla AWS_SECRET_ACCESS_KEY=blup node stress_test/lib/index.js",
+    "test:debug": "npm run build && APP_SPEC_NETWORK_TYPE=sim2h node --inspect stress_test/lib/index.js"
   }
 }

--- a/test/stress_test/easy.ts
+++ b/test/stress_test/easy.ts
@@ -16,6 +16,7 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
 
     scenario('all agents exists', async (s, t) => {
         const players = R.sortBy(p => parseInt(p.name, 10), R.values(await s.players(configBatch(totalConductors, I), false)))
+        const batch = new Batch(players).iteration('parallel')
 
         // range of random number of milliseconds to wait before startup
         // const startupSpacing = 10000
@@ -35,8 +36,6 @@ module.exports = (scenario, configBatch, N, C, I, sampleSize, spinUpDelay) => {
             console.log(`spin up delay ${spinUpDelay}`)
             await delay(spinUpDelay)
         }
-
-        const batch = new Batch(players).iteration('parallel')
 
         const agentIds = await batch.mapInstances(async instance => instance.agentAddress)
         let results = []

--- a/test/stress_test/index.ts
+++ b/test/stress_test/index.ts
@@ -28,7 +28,7 @@ switch (networkType) {
   case 'sim2h':
     network = {
       type: 'sim2h',
-      sim2h_url: "wss://localhost:9002",
+      sim2h_url: "ws://localhost:9002",
     }
     break
   case 'sim2h_public':
@@ -103,11 +103,28 @@ console.log("using dna: "+ JSON.stringify(chosenDna))
 console.log("using network: "+ JSON.stringify(network))
 const orchestrator = new Orchestrator({
     middleware,
+    waiter: {
+      softTimeout: 15000,
+      hardTimeout: 30000,
+
+      // new Waiter setting to use alternate NetworkModel
+      // if none specified, uses fullsync, otherwise an experimental sharding-aware network model
+      networkModel: {
+        type: 'naive-sharding',
+        redundancy: 10,
+      },
+      // networkModel: {
+      //   type: 'fullsync',
+      // },
+    }
 })
+
+const logger = Config.logger(true)
+logger.state_dump = false
 
 const commonConfig = {
   network,
-  logger: Config.logger(true),
+  logger,
   metric_publisher
 }
 


### PR DESCRIPTION
Uses new experimental NetworkModel which is sharding-aware in that it only awaits Holds from a certain number of distinct nodes, but it doesn't care exactly which nodes.

This is in contrast to the original fullsync NetworkModel, which waits for Holds from all participating nodes.

This may or may not work well. Since we aren't using the sharding algorithm to determine exactly which nodes to await holds from, and because the naive sharding has a wide variance of actual number of nodes which will validate an entry, we can only ask for a lower bound, which means the test may advance while other nodes are still working on holding an entry.